### PR TITLE
Change syntax for relative links

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To find out the full path for any node, right-click on the operator of interest 
 ```markdown
 ### **Exercise 7:** Control an LED
 
-![Control an LED](~/images/acquisition-led.svg)
+![Control an LED](../images/acquisition-led.svg)
 
 - Insert a [**`Boolean`**](xref:Bonsai.Expressions.BooleanProperty) source.
 - Insert a [**`DigitalOutput`**](xref:Bonsai.Arduino.DigitalOutput) sink.
@@ -61,5 +61,5 @@ Add the `.svg` file to the **images** folder in this repo, and add the `.bonsai`
 Assuming you want to include `acquisition-example.bonsai`: 
 
 ```markdown
-[![Example Workflow](~/images/acquisition-example.svg)](~/workflows/acquisition-example.bonsai)
+[![Example Workflow](../images/acquisition-example.svg)](../workflows/acquisition-example.bonsai)
 ```


### PR DESCRIPTION
I noticed that the ~ doesn't work in this repo for creating an absolute link to the root directory. Based on other project's suggestions online, I have changed these absolute links to relative links, which works locally.