### PR TITLE
Convert equivalent worksheet kramdown syntax to markdig

### DIFF
--- a/docfx.json
+++ b/docfx.json
@@ -80,6 +80,7 @@
     "markdownEngineName": "markdig",
     "markdownEngineProperties": {
       "markdigExtensions": [
+        "attributes",
         "customcontainers"
       ]
     },

--- a/templates/html/styles/main.css
+++ b/templates/html/styles/main.css
@@ -90,3 +90,11 @@
   opacity: 0;
   transition: 500ms opacity ease-in-out;
 }
+
+.diagram {
+  text-align: center;
+}
+
+summary {
+  display: list-item;
+}

--- a/worksheets/acquisition.md
+++ b/worksheets/acquisition.md
@@ -40,7 +40,7 @@ Audio data is captured at much higher temporal sampling frequencies than video. 
 - Make sure that the `SamplingFrequency` property of the `AudioWriter` matches the frequency of audio capture.
 - Run the workflow for some seconds. Playback the file in Windows Media Player to check that it is a valid audio file.
 
-### **Exercise 4 (Optional):** Saving raw binary waveform data
+### **Exercise 4:** Saving raw binary waveform data
 
 ![Saving raw binary waveform data](~/images/acquisition-audiobinary.svg)
 
@@ -178,7 +178,7 @@ _Describe in your own words what the above modified workflow is doing._
 - Run the workflow, point the camera at a moving object and visualize the output of the `Sum` operator. Compare small movements to big movements. What happens to the signal when the object holds perfect still?
 - Right-click the `Sum` operator. Select the `Scalar` > `Val0` member from the context menu.
 
-**Note:** The `Sum` operator sums the pixel values across all image colour channels. However, in the case of grayscale binary images, there is only one active channel and its sum is stored in the `Val0` field.
-{: .notice--info}
+> [!Note]
+> The `Sum` operator sums the pixel values across all image colour channels. However, in the case of grayscale binary images, there is only one active channel and its sum is stored in the `Val0` field.
 
 - Record the motion of an object using a `CsvWriter` sink.

--- a/worksheets/closed-loop.md
+++ b/worksheets/closed-loop.md
@@ -24,8 +24,8 @@ The easiest way to measure the latency of a closed-loop system is to use a digit
 - Insert a `TimeInterval` operator.
 - Right-click on the `TimeInterval` operator and select `Output` > `Interval` > `TotalMilliseconds`.
 
-**Note:** The `TimeInterval` operator measures the interval between consecutive events in an observable sequence using the [high-precision event timer (HPET)](https://en.wikipedia.org/wiki/High_Precision_Event_Timer) in the computer. The HPET has a frequency of at least 10MHz, allowing us to accurately time intervals with sub-microsecond precision.
-{: .notice--info}
+> [!Note]
+> The `TimeInterval` operator measures the interval between consecutive events in an observable sequence using the [high-precision event timer (HPET)](https://en.wikipedia.org/wiki/High_Precision_Event_Timer) in the computer. The HPET has a frequency of at least 10MHz, allowing us to accurately time intervals with sub-microsecond precision.
 
 - Run the workflow and measure the round-trip time between digital input messages.
 
@@ -38,13 +38,13 @@ The easiest way to measure the latency of a closed-loop system is to use a digit
 - Insert a `Crop` transform.
 - Run the workflow and set the `RegionOfInterest` property to a small area around the LED.
 
-**Hint:** You can use the visual editor for an easier calibration. While the workflow is running, right-click on the `Crop` transform and select `Show Default Editor` from the context menu or click in the small button with ellipsis that appears when you select the `RegionOfInterest` property.
-{: .notice--info}
+> [!Tip]
+> You can use the visual editor for an easier calibration. While the workflow is running, right-click on the `Crop` transform and select `Show Default Editor` from the context menu or click in the small button with ellipsis that appears when you select the `RegionOfInterest` property.
 
 - Insert a `Sum (Dsp)` transform and select the `Val2` field from the output.
 
-**Note:** The `Sum (Dsp)` operator adds the value of all the pixels in the image together, across all the color channels. Assuming the default BGR format, the result of summing all the pixels in the Red channel of the image will be stored in `Val2`. `Val0` and `Val1` would store the Blue and Green values, respectively. If you are using an LED with a color other than Red, please select the output field accordingly.
-{: .notice--info}
+> [!Note]
+> The `Sum (Dsp)` operator adds the value of all the pixels in the image together, across all the color channels. Assuming the default BGR format, the result of summing all the pixels in the Red channel of the image will be stored in `Val2`. `Val0` and `Val1` would store the Blue and Green values, respectively. If you are using an LED with a color other than Red, please select the output field accordingly.
 
 - Insert a `GreaterThan` transform.
 - Insert a `BitwiseNot` transform.
@@ -52,8 +52,8 @@ The easiest way to measure the latency of a closed-loop system is to use a digit
 - Run the workflow and use the visualizer of the `Sum` operator to choose an appropriate threshold for `GreaterThan`. When connected to pin 13, the LED should flash a couple of times when the Arduino is first connected.
 - Insert a [`DistinctUntilChanged`](https://bonsai-rx.org/docs/operators/distinctuntilchanged){:target="\_blank"} operator after the `BitwiseNot` transform.
 
-**Note:** The `DistinctUntilChanged` operator filters consecutive duplicate items from an observable sequence. In this case, we want to change the value of the LED only when the threshold output changes from `LOW` to `HIGH`, or vice-versa. This will let us measure correctly the latency between detecting a change in the input and measuring the response to that change.
-{: .notice--info}
+> [!Note]
+> The `DistinctUntilChanged` operator filters consecutive duplicate items from an observable sequence. In this case, we want to change the value of the LED only when the threshold output changes from `LOW` to `HIGH`, or vice-versa. This will let us measure correctly the latency between detecting a change in the input and measuring the response to that change.
 
 - Insert the `TimeInterval` operator and select `Output` > `Interval` > `TotalMilliseconds`.
 - Run the workflow and measure the round-trip time between LED triggers.
@@ -78,8 +78,8 @@ _Given the measurements obtained in Exercise 2, what would you estimate is the *
 - Run the workflow and verify that entering the region of interest triggers the Arduino LED.
 - **Optional:** Replace the `Crop` transform by a `CropPolygon` to allow for non-rectangular regions.
 
-**Note:** The `CropPolygon` operator uses the `Regions` property to define multiple, possibly non-rectangular regions. The visual editor is similar to `Crop`, where you draw a rectangular box. However, in `CropPolygon` you can move the corners of the box by right-clicking _inside_ the box and dragging the cursor to the new position. You can add new points by double-clicking with the left mouse button, and delete points by double-clicking with the right mouse button. You can delete regions by pressing the `Del` key and cycle through selected regions by pressing the `Tab` key.
-{: .notice--info}
+> [!Note]
+> The `CropPolygon` operator uses the `Regions` property to define multiple, possibly non-rectangular regions. The visual editor is similar to `Crop`, where you draw a rectangular box. However, in `CropPolygon` you can move the corners of the box by right-clicking _inside_ the box and dragging the cursor to the new position. You can add new points by double-clicking with the left mouse button, and delete points by double-clicking with the right mouse button. You can delete regions by pressing the `Del` key and cycle through selected regions by pressing the `Tab` key.
 
 ### **Exercise 4:** Modulating stimulus intensity based on distance to a point
 
@@ -102,16 +102,16 @@ The result of the `Subtract` operator will be a vector pointing from the target 
 - Insert an `ExpressionTransform` operator. This node allows you to write small mathematical and logical expressions to transform input values.
 - Right-click on the `ExpressionTransform` operator and select `Show Default Editor`. Set the expression to `Math.Sqrt(X*X + Y*Y)`.
 
-**Note:** Inside the `Expression` editor you can access any field of the input by name. In this case `X` and `Y` represent the corresponding fields of the `Point2f` data type. You can check which fields are available by right-clicking the previous node. You can use all the normal arithmetical and logical operators as well as the mathematical functions available in the [`Math`](<https://msdn.microsoft.com/en-us/library/system.math(v=vs.110).aspx>) type. The default expression `it` means "input" and represents the input value itself.
-{: .notice--info}
+> [!Note]
+> Inside the `Expression` editor you can access any field of the input by name. In this case `X` and `Y` represent the corresponding fields of the `Point2f` data type. You can check which fields are available by right-clicking the previous node. You can use all the normal arithmetical and logical operators as well as the mathematical functions available in the [`Math`](<https://msdn.microsoft.com/en-us/library/system.math(v=vs.110).aspx>) type. The default expression `it` means "input" and represents the input value itself.
 
 - Connect the `ExpressionTransform` operator to the externalized `Amplitude` property.
 - Run the workflow and verify that stimulus intensity is modulated by the distance of the object to the target point.
 - **Optional:** Modulate the `Frequency` property instead of `Amplitude`.
 - **Optional:** Use the `Rescale` operator to adjust the gain of the modulation by configuring the `Min`, `Max`, `RangeMax` and `RangeMin` properties. Set the `RescaleType` property to `Clamp` to restrict the output values to an allowed range.
 
-**Note:** You can specify inverse relationships using `Rescale` if you set the _maximum_ input value to the `Min` property, and the _minimum_ input value to the `Max` property. In this case, a small distance will generate a large output, and a large distance will produce a small output.
-{: .notice--info}
+> [!Note]
+> You can specify inverse relationships using `Rescale` if you set the _maximum_ input value to the `Min` property, and the _minimum_ input value to the `Max` property. In this case, a small distance will generate a large output, and a large distance will produce a small output.
 
 ### **Exercise 5:** Triggering a digital line based on distance between objects
 
@@ -171,8 +171,8 @@ We now want to map our negative centroid to the `Translation` property of `Affin
 - Open the `PropertyMappings` editor and add a new mapping to the `Translation` property.
 - Run the workflow. Verify the object is always placed at position (0,0). What is the problem?
 
-**Note:** Generally for image coordinates, (0,0) is at the top-left corner, and the center will be at coordinates (width/2, height/2), usually (320,240) for images with 640 x 480 resolution.
-{: .notice--info}
+> [!Note]
+> Generally for image coordinates, (0,0) is at the top-left corner, and the center will be at coordinates (width/2, height/2), usually (320,240) for images with 640 x 480 resolution.
 
 - Insert an `Add` transform. This will add a fixed offset to the point. Configure the `Value` property with an offset that will place the object at the image centre, e.g. (320,240).
 - Run the workflow, and verify the output of `WarpAffine` is now a video which is always centred on the tracked object.

--- a/worksheets/scripting.md
+++ b/worksheets/scripting.md
@@ -18,8 +18,8 @@ Install the following:
 3. [C# extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csharp) from the VS Code extensions menu.
 4. [.NET Framework 4.7.2 Developer Pack](https://dotnet.microsoft.com/download/dotnet-framework/net472).
 
-_You might need to reboot your machine after installing these components._
-{: .notice--info}
+> [!Warning]
+> You might need to reboot your machine after installing these components.
 
 ## Random Dot Kinematogram
 

--- a/worksheets/state-machines.md
+++ b/worksheets/state-machines.md
@@ -9,9 +9,9 @@ When designing operant behaviour assays in systems neuroscience, it is useful to
 
 For example, a simple reaction time task where the subject needs to press a button as fast as possible following a stimulus is described in the following diagram:
 
-<span style="display:block;text-align:center">
+:::diagram
 ![State Machine Diagram](~/images/reactiontime-task.svg)
-</span>
+:::
 
 The task begins with an inter-trial interval (`ITI`), followed by stimulus presentation (`ON`). After stimulus onset, advancement to the next state can happen only when the subject presses the button (`success`) or a timeout elapses (`miss`). Depending on which event is triggered first, the task advances either to the `Reward` state, or `Fail` state. At the end, the task goes back to the beginning of the ITI state for the next trial.
 
@@ -30,8 +30,8 @@ In this worksheet, we will be using an Arduino or a camera as an interface to de
 - Insert a `CsvWriter` sink and configure its `FileName` property with a file name ending in `.csv`.
 - Run the workflow and activate the digital sensor a couple of times. Stop the workflow and confirm that the events were successfully timestamped and logged in the `.csv` file.
 
-**Note**: In order to avoid hardware side-effects, it is highly recommended to declare all hardware connections at the top-level of the workflow, and interface all trial logic using subject variables. This will have the added benefit of allowing for very easy and centralized replacement of the rig hardware: as long as the new inputs and configurations are compatible with the logical subjects, no code inside the task logic will have to be changed at all.
-{: .notice--info}
+> [!Note]
+> In order to avoid hardware side-effects, it is highly recommended to declare all hardware connections at the top-level of the workflow, and interface all trial logic using subject variables. This will have the added benefit of allowing for very easy and centralized replacement of the rig hardware: as long as the new inputs and configurations are compatible with the logical subjects, no code inside the task logic will have to be changed at all.
 
 - Right-click the `DigitalInput` source, select `Create Source (bool)` > `BehaviorSubject`, and set its `Name` property to `Led`.
 - Insert a `DigitalOutput` sink and set it to Arduino pin 13.
@@ -46,19 +46,18 @@ Translating a state machine diagram into a Bonsai workflow begins by identifying
 - Insert a `Sink` operator and set its `Name` property to `StimOn`.
 - Double-click on the `Sink` node to open up its internal specification.
 
-**Note**: The `Sink` operator allows you to specify arbitrary processing side-effects without affecting the original flow of events. It is often used to trigger and control stimulus presentation in response to events in the task. Inside the nested specification, `Source1` represents input events arriving at the sink. In the specific case of `Sink` operators, the `WorkflowOutput` node can be safely ignored.
-{: .notice--info}
+> [!Note]
+> The `Sink` operator allows you to specify arbitrary processing side-effects without affecting the original flow of events. It is often used to trigger and control stimulus presentation in response to events in the task. Inside the nested specification, `Source1` represents input events arriving at the sink. In the specific case of `Sink` operators, the `WorkflowOutput` node can be safely ignored.
 
 **`StimOn`**:
 ![Stimulus LED control](~/images/statemachine-stimulus-led.svg)
-{: .notice--info}
 
 - Insert a `Boolean` operator following `Source1` and set its `Value` property to `True`.
 - Find and right-click the `Led` subject in the toolbox and select the option `Multicast`.
 - Run the workflow a couple of times and verify that the sequence of events is progressing correctly.
 
-**Note:** Opening a new connection to the Arduino can take several seconds due to the way the Firmata protocol is implemented. This may introduce a slight delay in starting the task. This delay is only present at the start of execution and will not affect the behavior of the state machine.
-{: .notice--info}
+> [!Note]
+> Opening a new connection to the Arduino can take several seconds due to the way the Firmata protocol is implemented. This may introduce a slight delay in starting the task. This delay is only present at the start of execution and will not affect the behavior of the state machine.
 
 ![Repeat stimulus presentation](~/images/statemachine-stimulus-repeat.svg)
 
@@ -79,12 +78,11 @@ Translating a state machine diagram into a Bonsai workflow begins by identifying
 - Insert a `SelectMany` operator after `StimOn`, and set its `Name` property to `Response`.
 - Double-click on the `SelectMany` node to open up its internal specification.
 
-**Note:** The `SelectMany` operator is used here to create a new state for every input event. `Source1` represents the input event that created the state, and `WorkflowOutput` will be used to report the end result from the state (e.g. whether the response was a success or failure).
-{: .notice--info}
+> [!Note]
+> The `SelectMany` operator is used here to create a new state for every input event. `Source1` represents the input event that created the state, and `WorkflowOutput` will be used to report the end result from the state (e.g. whether the response was a success or failure).
 
 **`Response`**:
 ![Stimulus response input control](~/images/statemachine-stimulus-response-input.svg)
-{: .notice--info}
 
 - Subscribe to the `Response` subject in the toolbox.
 - Insert a `Boolean` operator and set its `Value` property to `True`.
@@ -97,7 +95,6 @@ Translating a state machine diagram into a Bonsai workflow begins by identifying
 
 **`Response`**:
 ![Stimulus response timeout control](~/images/statemachine-stimulus-response-timeout.svg)
-{: .notice--info}
 
 - Inside the `Response` node, insert a `Timer` source and set its `DueTime` property to be about 1 second.
 - Insert a `Boolean` operator and set its `Value` property to `False`.
@@ -115,12 +112,11 @@ _Describe in your own words what the above modified workflow is doing._
 - In a new branch from `StimOff`, insert another `Condition`, and set its `Name` property to `Miss`.
 - Double-click on the `Condition` operator to open up its internal specification.
 
-**Note**: The `Condition` operator allows you to specify arbitrary rules for accepting or rejecting inputs. Only inputs which pass the filter specified inside the `Condition` are allowed to proceed. It is often used to represent choice points in the task. Inside the nested specification, `Source1` represents input events to be tested. The `WorkflowOutput` node always needs to be specified with a `bool` input, the result of whether the input is accepted (`True`) or rejected (`False`). Usually you can use operators such as `Equal`,`NotEqual`,`GreaterThan`, etc for specifying such tests.
-{: .notice--info}
+> [!Note]
+> The `Condition` operator allows you to specify arbitrary rules for accepting or rejecting inputs. Only inputs which pass the filter specified inside the `Condition` are allowed to proceed. It is often used to represent choice points in the task. Inside the nested specification, `Source1` represents input events to be tested. The `WorkflowOutput` node always needs to be specified with a `bool` input, the result of whether the input is accepted (`True`) or rejected (`False`). Usually you can use operators such as `Equal`,`NotEqual`,`GreaterThan`, etc for specifying such tests.
 
 **`Miss`**:
 ![Stimulus response miss condition](~/images/statemachine-stimulus-response-miss-condition.svg)
-{: .notice--info}
 
 - Insert a `BitwiseNot` operator after `Source1`.
 
@@ -130,7 +126,6 @@ _Why did we not need to specify anything for the `Success` condition?_
 - Inside the `Reward` node you can specify your own logic to signal the trial was successful. For example, you can make the LED blink three times in rapid succession:
 
 **`Reward`**: ![Stimulus response reward outcome](~/images/statemachine-stimulus-response-outcomes-reward.svg)
-{: .notice--info}
 
 - Insert a `Timer` node and set both the `DueTime` and the `Period` properties to 100ms.
 - Insert a `Mod` operator and set the `Value` property to 2.
@@ -138,7 +133,6 @@ _Why did we not need to specify anything for the `Success` condition?_
 - Find and right-click the `Led` subject in the toolbox and select the option `Multicast`.
 - Insert a `Take` operator and set the `Count` property to 6.
 - Insert the `Last` operator.
-  {: .notice--info}
 
 _Try out your state machine and check whether you understand the behavior of the reward signal._
 
@@ -149,7 +143,7 @@ _Try out your state machine and check whether you understand the behavior of the
 
 _Try out your state machine and introduce variations to the task behavior and conditions._
 
-### **Exercise 6 (Optional):** Go/No-Go task
+### **Exercise 6:** Go/No-Go task
 
 Implement the following trial structure for a Go/No-Go task.
 
@@ -159,15 +153,16 @@ Implement the following trial structure for a Go/No-Go task.
 - Response events should be based on a button press, and reject events on a timeout.
 - Make sure to implement different visual or auditory feedback for either the cue or reward/failure states.
 
-**Suggestion**: To sample values from a discrete uniform distribution, you can use the following workflow: ![Stimulus response reward outcome](~/images/samplediscreteuniform.svg)
-{: .notice--info}
+> [!Tip]
+> To sample values from a discrete uniform distribution, you can use the following workflow: ![Stimulus response reward outcome](~/images/samplediscreteuniform.svg)
 
 - Record a timestamped chronological log of trial types and rewards into a CSV file using a `BehaviorSubject`.
 
-### **Exercise 7 (Optional):** Conditioned place preference
+### **Exercise 7:** Conditioned place preference
 
 Implement the following trial structure for conditioned place preference. `enter` and `leave` events should be triggered in real-time from the camera, by tracking an object moving in or out of a region of interest (ROI). `Reward` should be triggered once upon entering the ROI, and not repeat again until the object exits the ROI and the ITI has elapsed.
 
 ![Conditioned Place Preference](~/images/placepreference.svg)
 
-**Suggestion**: There are several ways to implement ROI activation, so feel free to explore different ideas. Consider using either `Crop`, `RoiActivity`, or `ContainsPoint` as part of different strategies to implement the `enter` and `leave` events.
+> [!Tip]
+> There are several ways to implement ROI activation, so feel free to explore different ideas. Consider using either `Crop`, `RoiActivity`, or `ContainsPoint` as part of different strategies to implement the `enter` and `leave` events.

--- a/worksheets/synching-ephys.md
+++ b/worksheets/synching-ephys.md
@@ -3,6 +3,8 @@ layout: worksheet
 title: Ephys Synchronization
 ---
 
+# Ephys Synchronization
+
 Synchronizing behaviour and other experimental events with recorded neural data is a fundamental component of neuroscience data collection and analysis. The exercises below will walk you through some common cases encountered in systems neuroscience experiments, and how to deal with them using Bonsai.
 
 The general approach when synchronizing two independent data acquisition clocks is to record precise temporal events simultaneously in both systems. If you know that the two recorded events are the same, you know that those two time points are the same. When using multiple systems, it is common to choose the system with the fastest clock as _master_, and route all events to its analog or digital inputs.
@@ -32,7 +34,7 @@ The general approach when synchronizing two independent data acquisition clocks 
 - Open both the text file and the binary file in MATLAB/Python/R and check that you have detected an equal number of key presses in both files. What can you conclude from these two pieces of data?
 - **Optional:** Repeat the exercise, replacing the `KeyDown` source with a periodic `Timer`. Can you point out some of the limitations of synchronizing a video stream with ephys using this method?
 
-### **Exercise 3 (Optional):** Synchronizing video with ephys using GPIO
+### **Exercise 3:** Synchronizing video with ephys using GPIO
 
 Industrial grade cameras often include a GPIO connector which exposes input and output digital pins that operate similar to the pins in an Arduino or other microcontrollers. It is possible to configure these pins to report when the shutter of the camera is open or closed (i.e., when a frame is being exposed, the shutter is open and the pin goes `HIGH`, and conversely, when exposure stops, the shutter closes and the pin goes `LOW`).
 
@@ -58,8 +60,8 @@ In this exercise you will track the display of a very simple visual stimulus: a 
 - Insert a `Mod` transform and set its `Value` property to 2.
 - Insert a `Multiply` transform and set its `Value` property to 255.
 
-**Note:** The output of `Timer` is a growing count of the number of ticks. The `Mod` operator computes the remainder of the integer division of a number by another. Because every integer number in the sequence is alternately even or odd, the remainder of the division of the clock ticks by two will constantly oscillate between 0 and 1. Together with the `Multiply` operator, this is an easy way to make a periodic toggle between 0 and some value.
-{: .notice--info}
+> [!Note]
+> The output of `Timer` is a growing count of the number of ticks. The `Mod` operator computes the remainder of the integer division of a number by another. Because every integer number in the sequence is alternately even or odd, the remainder of the division of the clock ticks by two will constantly oscillate between 0 and 1. Together with the `Multiply` operator, this is an easy way to make a periodic toggle between 0 and some value.
 
 - Insert an `InputMapping` operator and connect it to the `SolidColor` source.
 - Edit the `PropertyMappings` and add a mapping to the `Color` property. You will have to select four times the input to fill all the components of the `Color` scalar.
@@ -69,7 +71,7 @@ In this exercise you will track the display of a very simple visual stimulus: a 
 - Connect a photodiode, or a photoresistor, to the ephys analog input and hold it flat against the screen, on top of the visualizer window.
 - Verify that you can capture the transitions between black and white in the ephys data using the photodiode.
 
-### **Exercise 5 (Optional):** Synchronizing video acquisition to a visual stimulus using GPIO
+### **Exercise 5:** Synchronizing video acquisition to a visual stimulus using GPIO
 
 The easiest way to synchronize the video acquisition with a visual stimulus is to make sure that your camera can see and track both your object of interest _and_ the visual stimulus. If you can extract the stimulus events from your video, then they are synchronized with all other video events by definition, since all pixels in a video frame are acquired synchronously.
 

--- a/worksheets/synching.md
+++ b/worksheets/synching.md
@@ -19,16 +19,16 @@ Synchronizing behaviour and other experimental events with stimulation or record
 
 _How would you test the synchronization between the two video streams?_
 
-**Note**: You can use the `FileCapture` source to inspect the video frame by frame by setting the `Playing` property to `False`. After setting the `FileName` property to match your recorded video, run the workflow, open the source visualizer, and then right-clicking on top of the video frame to open up the seek bar at the bottom. You can use the arrow keys to move forward and back on individual frames.
-{: .notice--info}
+> [!Note]
+> You can use the `FileCapture` source to inspect the video frame by frame by setting the `Playing` property to `False`. After setting the `FileName` property to match your recorded video, run the workflow, open the source visualizer, and then right-clicking on top of the video frame to open up the seek bar at the bottom. You can use the arrow keys to move forward and back on individual frames.
 
 ## Reaction Time
 
 For this and subsequent worksheets, we will use a simple reaction time task as our model systems neuroscience experiment. In this task, the subject needs to press a button as fast as possible following a stimulus, as described in the following diagram:
 
-<span style="display:block;text-align:center">
+:::diagram
 ![State Machine Diagram](~/images/reactiontime.svg)
-</span>
+:::
 
 The task begins with an inter-trial interval (`ITI`), followed by stimulus presentation (`ON`). After stimulus onset, advancement to the next state can happen only when the subject presses the button (`success`) or a timeout elapses (`miss`). Depending on which event is triggered first, the task advances either to the `Reward` state, or `Fail` state. At the end, the task goes back to the beginning of the ITI state for the next trial.
 
@@ -36,7 +36,7 @@ The task begins with an inter-trial interval (`ITI`), followed by stimulus prese
 
 In this first exercise, you will assemble the basic hardware and software components required to implement the reaction time task. The wiring diagram below illustrates the hardware assembly. You can wire the LED into any digital input pin, but make sure to note the pin number for the steps below.
 
-![Reaction Time Circuit](~/images/reaction-time-circuit.png){:height="300px"}
+![Reaction Time Circuit](~/images/reaction-time-circuit.png){height=300}
 
 We will start by using a fixed-interval blinking LED as our stimulus.
 

--- a/worksheets/vision-psychophysics.md
+++ b/worksheets/vision-psychophysics.md
@@ -8,10 +8,10 @@ title: Vision Psychophysics
 ## Getting Started
 
 1. Install the **BonVision** package from the Bonsai Community feed in the package manager. ![Installing BonVision](~/images/bonvision-install.png)
-2. Go through the [basic stimuli tutorial](https://bonvision.github.io/pages/03-Creating-Basic-Stimuli){:target="\_blank"} at the [BonVision](https://bonvision.github.io/){:target="\_blank"} website.
+2. Go through the [basic stimuli tutorial](https://bonvision.github.io/pages/03-Creating-Basic-Stimuli){target="\_blank"} at the [BonVision](https://bonvision.github.io/){target="\_blank"} website.
 
-**Make sure the latest version of the BonVision package is installed for this worksheet**
-{: .notice--info}
+> [!Warning]
+> Make sure the latest version of the BonVision package is installed for this worksheet.
 
 ## Orientation Discrimination
 
@@ -46,14 +46,13 @@ For now, we start by displaying a repeating sequence of random orientation grati
 - Insert a `SelectMany` operator and set its name to `ReferenceGrating`.
 - Insert a `Repeat` operator.
 
-**Note**: The `Timer (Shaders)` source works exactly like the default `Timer (Reactive)` source, but it counts the time by using the screen refresh time, rather than the operating system time. This can be important for precise timing of screen stimuli, as it avoid clock drift and jitter when synchronizing multiple visual elements, and should be in general preferred when specifying the various intervals used to control elements in the BonVision or Shaders packages.
-{: .notice--info}
+> [!Note]
+> The `Timer (Shaders)` source works exactly like the default `Timer (Reactive)` source, but it counts the time by using the screen refresh time, rather than the operating system time. This can be important for precise timing of screen stimuli, as it avoid clock drift and jitter when synchronizing multiple visual elements, and should be in general preferred when specifying the various intervals used to control elements in the BonVision or Shaders packages.
 
 To implement the `ReferenceGrating` state, we will need to sample a random angle from the angle distribution, use it to initialize the angle property of the gratings, and present the gratings for a specified period of time. At the end, we need to send out as a result the value of the random orientation which was generated.
 
 **`ReferenceGrating`**:
 ![BonVision render loop](~/images/bonvision-render-randomgrating.svg)
-{: .notice--info}
 
 - Use the `Sample (Numerics)` operator to sample a random orientation value from the `AngleDistribution` subject and store it in a new `AsyncSubject` named `Angle`. This will allow us to reuse the sampled value when drawing the gratings later.
 - Subscribe to the `Draw` subject we defined previously and insert a `DrawGratings` operator.
@@ -72,7 +71,6 @@ The second step in defining the contrast discrimination task is to display a sec
 
 **`ReferenceGrating`**:
 ![BonVision render loop](~/images/bonvision-render-referencegrating.svg)
-{: .notice--info}
 
 - Inside the `ReferenceGrating` state, select all nodes before `WorkflowOutput`, right-click the selection, and choose the `Save as Workflow` option. Choose `RandomOrientationGrating` as the name for the extension.
 
@@ -88,18 +86,16 @@ For the `Blank` state we will use a simple gap interval where nothing is drawn o
 
 **`Blank`**:
 ![BonVision render loop](~/images/bonvision-render-blank.svg)
-{: .notice--info}
 
 - Insert a `Delay (Shaders)` operator between the input and the output of the state workflow.
 
-**Note**: Similar to `Timer (Shaders)`, the `Delay (Shaders)` operator works exactly like the `Delay (Reactive)` operator, but using the screen refresh clock instead of the operating system clock. This also ensures that any delayed notifications are resynchronized with the render loop, in case they were emitted from other external devices.
-{: .notice--info}
+> [!Note]
+> Similar to `Timer (Shaders)`, the `Delay (Shaders)` operator works exactly like the `Delay (Reactive)` operator, but using the screen refresh clock instead of the operating system clock. This also ensures that any delayed notifications are resynchronized with the render loop, in case they were emitted from other external devices.
 
 To implement the `TestGrating` state, we want to reuse our previous `RandomOrientationGrating` extension workflow and simply combine the random generated angle with the angle from the reference grating.
 
 **`TestGrating`**:
 ![BonVision render loop](~/images/bonvision-render-testgrating.svg)
-{: .notice--info}
 
 - Insert a new `RandomOrientationGrating` operator from the toolbox and combine it with the input by using the `Zip` combinator. This will generate a pair where the first value is the random angle from the first reference grating, and the second value is the random angle for this test grating.
 
@@ -117,13 +113,12 @@ To implement the response gathering state we will use key presses from the parti
 
 **`Response`**:
 ![BonVision render loop](~/images/bonvision-response-choice.svg)
-{: .notice--info}
 
 - Connect the `Draw` subject from the toolbox to a new `DrawText` operator and set its `Text` property to a suggestive question (e.g. `A or B?`). Also edit the `Font` property and make sure the size is at least 72pt for readability.
 - Insert a `DelaySubscription (Shaders)` operator and set its `DueTime` property to 1 second.
 
-**Note**: As before, the difference with `DelaySubscription (Reactive)` is that `DelaySubscription (Shaders)` will use the screen refresh time and make sure that all effects of subscription are synchronized with the render loop.
-{: .notice--info}
+> [!Note]
+> As before, the difference with `DelaySubscription (Reactive)` is that `DelaySubscription (Shaders)` will use the screen refresh time and make sure that all effects of subscription are synchronized with the render loop.
 
 - Insert a `LessThan` operator after the input source node. This will compare the value of the randomly sampled angles for the first and second gratings, respectively, and will return true if the first grating is more clockwise than the second grating (i.e. its angle in radians is smaller than the second grating).
 - Insert a `KeyDown (Shaders)` source and set its `Key` property to `Left`.
@@ -146,7 +141,6 @@ This final state will simply display a quad for a certain period of time, where 
 
 **`Feedback`**:
 ![BonVision render loop](~/images/bonvision-response-feedback.svg)
-{: .notice--info}
 
 - Insert an `AsyncSubject` operator and set its `Name` property to `Result`. This will store the trial outcome result so it can be used to compute the color value of the quad.
 - Subscribe to the `Draw` subject and insert a `DrawQuad` operator.


### PR DESCRIPTION
This PR converts the existing worksheets to markdig compatible syntax. To make everything work we enabled a few CSS elements for `summary` HTML tags and a new CSS class for centered diagrams (`.diagram`).

Fixes #36 