### PR TITLE
Rename main headers

### DIFF
--- a/toc.yml
+++ b/toc.yml
@@ -1,6 +1,6 @@
-- name: Manual
+- name: Documentation
   href: articles/
-- name: Reference
+- name: API
   href: api/
 - name: Tutorials
   href: tutorials/


### PR DESCRIPTION
This is for consistency with single package documentation websites. We will probably want to revisit CI and layout structure for this website as well, but in the meantime this will align the frontend look-and-feel.