### PR TITLE
Add WinGet installation instructions

### DIFF
--- a/articles/installation.md
+++ b/articles/installation.md
@@ -16,3 +16,9 @@ The latest stable release is: **2.9.0**
 [Release Notes](https://github.com/bonsai-rx/bonsai/releases?q=prerelease%3Afalse)
 
 The installer will make sure that .NET and any other required system dependencies for running Bonsai are correctly setup in your computer.
+
+> [!TIP]
+> On Windows 10 (1809+) and above, Bonsai can be installed from the command line using the Windows Package Manager [WinGet](https://github.com/microsoft/winget-cli):
+> ```cmd
+> winget install bonsai-rx
+> ```


### PR DESCRIPTION
Update installation instructions to add WinGet as an alternative installation method, now that Bonsai has been registered with WinGet.

The command `winget install bonsai-rx` locates Bonsai using the `bonsai-rx` moniker, which seems to be the simplest and cleanest installation command for people to remember.

Some notes:
- To be more precise, one can use the package ID `BonsaiFoundation.Bonsai` instead, but I thought it would be too long for people to remember.
- We can add some details on using the `-v` parameter to specify a version, but in general, I guess we want people to use the latest version of the Bonsai installer when installing Bonsai system-wide.
- For futureproofing, we can add `winget upgrade bonsai-rx`, but only Bonsai 2.9 is registered so far. I am not sure how this would work on a system with an older Bonsai version installed (<2.9).
- I noticed that Windows Sandbox does not come with WinGet. For people who want to test the command out in Sandbox they have to [install WinGet](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget-on-windows-sandbox). There will also be an error with `msstore` as a source, one can remove `msstore` with `winget source remove msstore` (msstore does not work in Sandbox without [additional steps](https://www.windowslatest.com/2025/10/27/how-i-installed-microsoft-store-in-windows-sandbox-with-powershell-script/)).
- Depending on enterprise IT policy, WinGet might not be available on certain Windows computers or there might be other issues. To avoid overcomplicating the instructions, I added an external link to the winget-cli repository, as there is a troubleshooting guide.

